### PR TITLE
Hardcoding path to `pdfinfo` to avoid custom build bug

### DIFF
--- a/remarkable-cp
+++ b/remarkable-cp
@@ -63,7 +63,7 @@ echo """{
     \"visibleName\": \"$NAME\"
 }""" > device/${NEW_UUID}.metadata
 
-PAGES_NUM=`pdfinfo $FILEPATH | grep Pages | sed 's/[^0-9]*//'`
+PAGES_NUM=`/usr/bin/pdfinfo $FILEPATH | grep Pages | sed 's/[^0-9]*//'`
 echo """{
     \"extraMetadata\": {
         \"LastColor\": \"Black\",


### PR DESCRIPTION
- there are issues if a custom build installation of pdfinfo exists on the system
- need to hardcode the path to the original installation of pdfinfo